### PR TITLE
Remove Python 2.7 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.5"
 install:
     - travis_retry pip install -r requirements.txt


### PR DESCRIPTION
Python 2 is not supported as of 91dc10f0a29bb824214233d2831d09f01456f241